### PR TITLE
fix: relax import syntax constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ type Post {
 }
 ```
 
+Valid import comments are prefixed either with `#import ` or `#import ` and have a suffix of a path relative from the GraphQL file's path.
+
 ### Recommendations
 
 #### Optimize Your DocumentNodes

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,14 +61,19 @@ var parseGraphQLFile = (filePath) => new Promise((resolve) => {
   let body = "";
   const imports = [];
   let hasExhaustedImports = false;
+  const parseImportAndCapture = (importCommentPrefix, line) => {
+    const relativePath = line.replace(importCommentPrefix, "");
+    const absolutePath = path.default.join(path.default.dirname(filePath), relativePath);
+    imports.push({
+      absolutePath,
+      relativePath
+    });
+  };
   readInterface.on("line", (line) => {
     if (line.startsWith("#import ")) {
-      const relativePath = line.replace("#import ", "");
-      const absolutePath = path.default.join(path.default.dirname(filePath), relativePath);
-      imports.push({
-        absolutePath,
-        relativePath
-      });
+      parseImportAndCapture("#import ", line);
+    } else if (line.startsWith("# import ")) {
+      parseImportAndCapture("# import ", line);
     } else if (hasExhaustedImports) {
       body += line + "\n";
     } else if (line[0] !== "#" && line !== "") {

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -31,14 +31,19 @@ var parseGraphQLFile = (filePath) => new Promise((resolve) => {
   let body = "";
   const imports = [];
   let hasExhaustedImports = false;
+  const parseImportAndCapture = (importCommentPrefix, line) => {
+    const relativePath = line.replace(importCommentPrefix, "");
+    const absolutePath = path2.join(path2.dirname(filePath), relativePath);
+    imports.push({
+      absolutePath,
+      relativePath
+    });
+  };
   readInterface.on("line", (line) => {
     if (line.startsWith("#import ")) {
-      const relativePath = line.replace("#import ", "");
-      const absolutePath = path2.join(path2.dirname(filePath), relativePath);
-      imports.push({
-        absolutePath,
-        relativePath
-      });
+      parseImportAndCapture("#import ", line);
+    } else if (line.startsWith("# import ")) {
+      parseImportAndCapture("# import ", line);
     } else if (hasExhaustedImports) {
       body += line + "\n";
     } else if (line[0] !== "#" && line !== "") {

--- a/tests/cases/simple-graphql-import-with-space-case/index.ts
+++ b/tests/cases/simple-graphql-import-with-space-case/index.ts
@@ -1,0 +1,3 @@
+import schema from './target.graphql';
+
+export default schema;

--- a/tests/cases/simple-graphql-import-with-space-case/simple-graphql-import-with-space-case.test.ts
+++ b/tests/cases/simple-graphql-import-with-space-case/simple-graphql-import-with-space-case.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../utilities';
 import output from './output';
 
-describe('simple graphql import case', () => {
+describe('simple import case with a space', () => {
   it('generates the expected output', () => {
     const targetFile = path.join(__dirname, './target.graphql');
     const userFile = path.join(__dirname, './user.graphql');

--- a/tests/cases/simple-graphql-import-with-space-case/target.graphql
+++ b/tests/cases/simple-graphql-import-with-space-case/target.graphql
@@ -1,0 +1,14 @@
+# import ./user.graphql
+
+type Post {
+  id: ID!
+  author: User!
+}
+
+type Query {
+  posts: [Post!]!
+}
+
+schema {
+  query: Query
+}

--- a/tests/cases/simple-graphql-import-with-space-case/user.graphql
+++ b/tests/cases/simple-graphql-import-with-space-case/user.graphql
@@ -1,0 +1,5 @@
+type User {
+  id: ID!
+  name: String!
+  email: String!
+}


### PR DESCRIPTION
This allows for importing GraphQL files either through #import or # import comments.