### PR TITLE
feat: add ability to import multiple operations by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,27 @@ build({
 });
 ```
 
+With this in place, you should now be able to import GraphQL like so:
+
+```ts
+import schema from './schema.graphql';
+
+// Do whatever with the schema DocumentNode...
+```
+
+Also, all operations are named exports, so you can do things like this:
+
+```ts
+import {
+  QueryA,
+  QueryB,
+  MutationA,
+  SubscriptionA,
+} from './my-operations.graphql';
+
+// Do whatever with those operations...
+```
+
 ### GraphQL File Imports
 
 You can import files from within GraphQL files by using imports in comments like so:

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,9 +33,8 @@ var fs = __toModule(require("fs"));
 var graphql_tag = __toModule(require("graphql-tag"));
 var readline = __toModule(require("readline"));
 var path = __toModule(require("path"));
-var generateDocumentNodeString = (graphqlString, mapDocumentNode) => {
-  const ast = graphql_tag.default(graphqlString);
-  const documentNodeToUse = mapDocumentNode ? mapDocumentNode(ast) : ast;
+var generateDocumentNodeString = (graphqlDocument, mapDocumentNode) => {
+  const documentNodeToUse = mapDocumentNode ? mapDocumentNode(graphqlDocument) : graphqlDocument;
   return JSON.stringify(documentNodeToUse, (key, value) => value === void 0 ? "__undefined" : value).replace(/"__undefined"/g, "undefined");
 };
 var topologicallySortParsedFiles = (parsedFiles, cache) => {
@@ -117,11 +116,24 @@ var generateGraphQLString = (entryPointPath) => {
     return graphqlString;
   });
 };
+var generateContentsFromGraphqlString = (graphqlString, mapDocumentNode) => {
+  const graphqlDocument = graphql_tag.default(graphqlString);
+  const documentNodeAsString = generateDocumentNodeString(graphqlDocument, mapDocumentNode);
+  const lines = graphqlDocument.definitions.reduce((accumulator, definition, index) => {
+    if (definition.kind === "OperationDefinition" && definition.name && definition.name.value) {
+      const name = definition.name.value;
+      accumulator.push(`export const ${name} = documentNode.definitions[${index}];`);
+    }
+    return accumulator;
+  }, [`const documentNode = ${documentNodeAsString};`]);
+  lines.push(`export default documentNode;`);
+  return lines.join("\n");
+};
 var graphqlLoaderPlugin = (options = {}) => ({
   name: "graphql-loader",
   setup(build) {
     build.onLoad({filter: options.filterRegex || /\.graphql$/}, (args) => generateGraphQLString(args.path).then((graphqlString) => ({
-      contents: `export default ${generateDocumentNodeString(graphqlString, options.mapDocumentNode)};`
+      contents: generateContentsFromGraphqlString(graphqlString, options.mapDocumentNode)
     })));
   }
 });

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -3,9 +3,8 @@ import fs2 from "fs";
 import gql from "graphql-tag";
 import readline2 from "readline";
 import path2 from "path";
-var generateDocumentNodeString = (graphqlString, mapDocumentNode) => {
-  const ast = gql(graphqlString);
-  const documentNodeToUse = mapDocumentNode ? mapDocumentNode(ast) : ast;
+var generateDocumentNodeString = (graphqlDocument, mapDocumentNode) => {
+  const documentNodeToUse = mapDocumentNode ? mapDocumentNode(graphqlDocument) : graphqlDocument;
   return JSON.stringify(documentNodeToUse, (key, value) => value === void 0 ? "__undefined" : value).replace(/"__undefined"/g, "undefined");
 };
 var topologicallySortParsedFiles = (parsedFiles, cache) => {
@@ -87,11 +86,24 @@ var generateGraphQLString = (entryPointPath) => {
     return graphqlString;
   });
 };
+var generateContentsFromGraphqlString = (graphqlString, mapDocumentNode) => {
+  const graphqlDocument = gql(graphqlString);
+  const documentNodeAsString = generateDocumentNodeString(graphqlDocument, mapDocumentNode);
+  const lines = graphqlDocument.definitions.reduce((accumulator, definition, index) => {
+    if (definition.kind === "OperationDefinition" && definition.name && definition.name.value) {
+      const name = definition.name.value;
+      accumulator.push(`export const ${name} = documentNode.definitions[${index}];`);
+    }
+    return accumulator;
+  }, [`const documentNode = ${documentNodeAsString};`]);
+  lines.push(`export default documentNode;`);
+  return lines.join("\n");
+};
 var graphqlLoaderPlugin = (options = {}) => ({
   name: "graphql-loader",
   setup(build) {
     build.onLoad({filter: options.filterRegex || /\.graphql$/}, (args) => generateGraphQLString(args.path).then((graphqlString) => ({
-      contents: `export default ${generateDocumentNodeString(graphqlString, options.mapDocumentNode)};`
+      contents: generateContentsFromGraphqlString(graphqlString, options.mapDocumentNode)
     })));
   }
 });

--- a/tests/cases/multiple-operation-imports/index.ts
+++ b/tests/cases/multiple-operation-imports/index.ts
@@ -1,0 +1,3 @@
+import defaultExport from './target.graphql';
+export * from './target.graphql';
+export default defaultExport;

--- a/tests/cases/multiple-operation-imports/multiple-operation-imports.test.ts
+++ b/tests/cases/multiple-operation-imports/multiple-operation-imports.test.ts
@@ -1,0 +1,26 @@
+import path from 'path';
+
+import {
+  getJSONDocumentNodeFromString,
+  importFileAsString,
+} from '../utilities';
+import * as AllExports from './output';
+
+describe('multiple operation imports', () => {
+  it('generates the expected output', () => {
+    const targetFile = path.join(__dirname, './target.graphql');
+    return importFileAsString(targetFile).then((data) => {
+      const expected = getJSONDocumentNodeFromString(data);
+
+      expect(AllExports).toEqual({
+        default: expected,
+        QueryA: expected.definitions[0],
+        QueryB: expected.definitions[1],
+        MutationA: expected.definitions[2],
+        MutationB: expected.definitions[3],
+        SubscriptionA: expected.definitions[4],
+        SubscriptionB: expected.definitions[5],
+      });
+    });
+  });
+});

--- a/tests/cases/multiple-operation-imports/target.graphql
+++ b/tests/cases/multiple-operation-imports/target.graphql
@@ -1,0 +1,40 @@
+query QueryA {
+  getThings {
+    name
+  }
+}
+
+query QueryB {
+  getOtherThings {
+    name
+  }
+}
+
+query MutationA {
+  mutate {
+    name
+  }
+}
+
+query MutationB {
+  mutate {
+    name
+  }
+}
+
+subscription SubscriptionA($postID: ID!) {
+  commentAdded(postID: $postID) {
+    id
+    content
+  }
+}
+
+subscription SubscriptionB($postID: ID!) {
+  commentDeleted(postID: $postID) {
+    id
+  }
+}
+
+type SomeThingThatIsNotAnOperation {
+  id: ID!
+}


### PR DESCRIPTION
This change makes it such that all operations found on the top-level DocumentNode are exported by
name by reference to their respective definitions in the default exported DocumentNode object.

re #10