### PR TITLE
fix: wrap named export operations in documents

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -116,13 +116,15 @@ var generateGraphQLString = (entryPointPath) => {
     return graphqlString;
   });
 };
+var generateDocumentNodeStringForOperationDefinition = (rootDocumentIndex) => `{kind:"Document",definitions:[documentNode.definitions[${rootDocumentIndex}]]}`;
 var generateContentsFromGraphqlString = (graphqlString, mapDocumentNode) => {
   const graphqlDocument = graphql_tag.default(graphqlString);
   const documentNodeAsString = generateDocumentNodeString(graphqlDocument, mapDocumentNode);
   const lines = graphqlDocument.definitions.reduce((accumulator, definition, index) => {
     if (definition.kind === "OperationDefinition" && definition.name && definition.name.value) {
       const name = definition.name.value;
-      accumulator.push(`export const ${name} = documentNode.definitions[${index}];`);
+      const operationDocumentString = generateDocumentNodeStringForOperationDefinition(index);
+      accumulator.push(`export const ${name} = ${operationDocumentString};`);
     }
     return accumulator;
   }, [`const documentNode = ${documentNodeAsString};`]);

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -86,13 +86,15 @@ var generateGraphQLString = (entryPointPath) => {
     return graphqlString;
   });
 };
+var generateDocumentNodeStringForOperationDefinition = (rootDocumentIndex) => `{kind:"Document",definitions:[documentNode.definitions[${rootDocumentIndex}]]}`;
 var generateContentsFromGraphqlString = (graphqlString, mapDocumentNode) => {
   const graphqlDocument = gql(graphqlString);
   const documentNodeAsString = generateDocumentNodeString(graphqlDocument, mapDocumentNode);
   const lines = graphqlDocument.definitions.reduce((accumulator, definition, index) => {
     if (definition.kind === "OperationDefinition" && definition.name && definition.name.value) {
       const name = definition.name.value;
-      accumulator.push(`export const ${name} = documentNode.definitions[${index}];`);
+      const operationDocumentString = generateDocumentNodeStringForOperationDefinition(index);
+      accumulator.push(`export const ${name} = ${operationDocumentString};`);
     }
     return accumulator;
   }, [`const documentNode = ${documentNodeAsString};`]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Plugin } from 'esbuild';
 import fs from 'fs';
 import gql from 'graphql-tag';
-import { DocumentNode } from 'graphql';
+import { OperationDefinitionNode, DocumentNode } from 'graphql';
 import readline from 'readline';
 import path from 'path';
 
@@ -146,6 +146,11 @@ const generateGraphQLString = (entryPointPath: string): Promise<string> => {
   });
 };
 
+const generateDocumentNodeStringForOperationDefinition = (
+  rootDocumentIndex: number
+): string =>
+  `{kind:"Document",definitions:[documentNode.definitions[${rootDocumentIndex}]]}`;
+
 const generateContentsFromGraphqlString = (
   graphqlString: string,
   mapDocumentNode?: (documentNode: DocumentNode) => DocumentNode
@@ -164,9 +169,10 @@ const generateContentsFromGraphqlString = (
         definition.name.value
       ) {
         const name = definition.name.value;
-        accumulator.push(
-          `export const ${name} = documentNode.definitions[${index}];`
+        const operationDocumentString = generateDocumentNodeStringForOperationDefinition(
+          index
         );
+        accumulator.push(`export const ${name} = ${operationDocumentString};`);
       }
 
       return accumulator;

--- a/tests/cases/multiple-operation-imports/multiple-operation-imports.test.ts
+++ b/tests/cases/multiple-operation-imports/multiple-operation-imports.test.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import {
+  generateJSONDocumentNodeFromOperationDefinition,
   getJSONDocumentNodeFromString,
   importFileAsString,
 } from '../utilities';
@@ -14,12 +15,24 @@ describe('multiple operation imports', () => {
 
       expect(AllExports).toEqual({
         default: expected,
-        QueryA: expected.definitions[0],
-        QueryB: expected.definitions[1],
-        MutationA: expected.definitions[2],
-        MutationB: expected.definitions[3],
-        SubscriptionA: expected.definitions[4],
-        SubscriptionB: expected.definitions[5],
+        QueryA: generateJSONDocumentNodeFromOperationDefinition(
+          expected.definitions[0]
+        ),
+        QueryB: generateJSONDocumentNodeFromOperationDefinition(
+          expected.definitions[1]
+        ),
+        MutationA: generateJSONDocumentNodeFromOperationDefinition(
+          expected.definitions[2]
+        ),
+        MutationB: generateJSONDocumentNodeFromOperationDefinition(
+          expected.definitions[3]
+        ),
+        SubscriptionA: generateJSONDocumentNodeFromOperationDefinition(
+          expected.definitions[4]
+        ),
+        SubscriptionB: generateJSONDocumentNodeFromOperationDefinition(
+          expected.definitions[5]
+        ),
       });
     });
   });

--- a/tests/cases/utilities.ts
+++ b/tests/cases/utilities.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import gql from 'graphql-tag';
-import { DocumentNode } from 'graphql';
+import { DefinitionNode, DocumentNode } from 'graphql';
 
 interface JSONLocation {
   end: number;
@@ -10,6 +10,13 @@ interface JSONLocation {
 interface JSONDocumentNode extends Omit<DocumentNode, 'loc'> {
   loc?: JSONLocation;
 }
+
+export const generateJSONDocumentNodeFromOperationDefinition = (
+  operationDefinition: DefinitionNode
+): JSONDocumentNode => ({
+  kind: 'Document',
+  definitions: [operationDefinition],
+});
 
 // DocumentNode Location instances have a toJSON on them. That means that by
 // default, when JSON.stringify is called, is will call that method. That ends


### PR DESCRIPTION
Exported operations must be documents, not just definitions. This modifies the operation exports so
that they are documents instead of just definitions.