### PR TITLE
feat: make named exports of operations more tree-shakeable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -116,14 +116,20 @@ var generateGraphQLString = (entryPointPath) => {
     return graphqlString;
   });
 };
-var generateDocumentNodeStringForOperationDefinition = (rootDocumentIndex) => `{kind:"Document",definitions:[documentNode.definitions[${rootDocumentIndex}]]}`;
+var generateDocumentNodeStringForOperationDefinition = (operationDefinition, mapDocumentNode) => {
+  const operationDocument = {
+    kind: "Document",
+    definitions: [operationDefinition]
+  };
+  return generateDocumentNodeString(operationDocument, mapDocumentNode);
+};
 var generateContentsFromGraphqlString = (graphqlString, mapDocumentNode) => {
   const graphqlDocument = graphql_tag.default(graphqlString);
   const documentNodeAsString = generateDocumentNodeString(graphqlDocument, mapDocumentNode);
-  const lines = graphqlDocument.definitions.reduce((accumulator, definition, index) => {
+  const lines = graphqlDocument.definitions.reduce((accumulator, definition) => {
     if (definition.kind === "OperationDefinition" && definition.name && definition.name.value) {
       const name = definition.name.value;
-      const operationDocumentString = generateDocumentNodeStringForOperationDefinition(index);
+      const operationDocumentString = generateDocumentNodeStringForOperationDefinition(definition, mapDocumentNode);
       accumulator.push(`export const ${name} = ${operationDocumentString};`);
     }
     return accumulator;

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -86,14 +86,20 @@ var generateGraphQLString = (entryPointPath) => {
     return graphqlString;
   });
 };
-var generateDocumentNodeStringForOperationDefinition = (rootDocumentIndex) => `{kind:"Document",definitions:[documentNode.definitions[${rootDocumentIndex}]]}`;
+var generateDocumentNodeStringForOperationDefinition = (operationDefinition, mapDocumentNode) => {
+  const operationDocument = {
+    kind: "Document",
+    definitions: [operationDefinition]
+  };
+  return generateDocumentNodeString(operationDocument, mapDocumentNode);
+};
 var generateContentsFromGraphqlString = (graphqlString, mapDocumentNode) => {
   const graphqlDocument = gql(graphqlString);
   const documentNodeAsString = generateDocumentNodeString(graphqlDocument, mapDocumentNode);
-  const lines = graphqlDocument.definitions.reduce((accumulator, definition, index) => {
+  const lines = graphqlDocument.definitions.reduce((accumulator, definition) => {
     if (definition.kind === "OperationDefinition" && definition.name && definition.name.value) {
       const name = definition.name.value;
-      const operationDocumentString = generateDocumentNodeStringForOperationDefinition(index);
+      const operationDocumentString = generateDocumentNodeStringForOperationDefinition(definition, mapDocumentNode);
       accumulator.push(`export const ${name} = ${operationDocumentString};`);
     }
     return accumulator;

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,9 +147,16 @@ const generateGraphQLString = (entryPointPath: string): Promise<string> => {
 };
 
 const generateDocumentNodeStringForOperationDefinition = (
-  rootDocumentIndex: number
-): string =>
-  `{kind:"Document",definitions:[documentNode.definitions[${rootDocumentIndex}]]}`;
+  operationDefinition: OperationDefinitionNode,
+  mapDocumentNode?: (documentNode: DocumentNode) => DocumentNode
+): string => {
+  const operationDocument: DocumentNode = {
+    kind: 'Document',
+    definitions: [operationDefinition],
+  };
+
+  return generateDocumentNodeString(operationDocument, mapDocumentNode);
+};
 
 const generateContentsFromGraphqlString = (
   graphqlString: string,
@@ -162,7 +169,7 @@ const generateContentsFromGraphqlString = (
   );
 
   const lines = graphqlDocument.definitions.reduce<string[]>(
-    (accumulator, definition, index) => {
+    (accumulator, definition) => {
       if (
         definition.kind === 'OperationDefinition' &&
         definition.name &&
@@ -170,7 +177,8 @@ const generateContentsFromGraphqlString = (
       ) {
         const name = definition.name.value;
         const operationDocumentString = generateDocumentNodeStringForOperationDefinition(
-          index
+          definition,
+          mapDocumentNode
         );
         accumulator.push(`export const ${name} = ${operationDocumentString};`);
       }


### PR DESCRIPTION
This change makes it such that named exports of operations no longer refer to definitions of the
root DocumentNode by reference, but instead have the actual values put in place. This means that if
someone imports only one operation from a file that contains multiple operations, the code for the
unused operations should no longer be included.