### PR TITLE
feat: support deeply nested fragments in named export operations

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -134,18 +134,25 @@ var collectAllFragmentDefinitions = (documentNode) => {
   };
   return accumulateAllFragments(documentNode.definitions, {});
 };
-var collectAllFragmentReferences = (operationNode) => {
+var collectAllFragmentReferences = (node, allFragments) => {
   const references = [];
-  operationNode.selectionSet.selections.forEach((selection) => {
-    var _a;
-    if (selection.kind === "Field") {
-      (_a = selection.selectionSet) == null ? void 0 : _a.selections.forEach((selection2) => {
-        if (selection2.kind === "FragmentSpread") {
-          references.push(selection2.name.value);
-        }
-      });
+  const handleSelectionNode = (selection) => {
+    if (selection.kind === "FragmentSpread") {
+      const fragment = allFragments[selection.name.value];
+      const innerFragmentReferences = collectAllFragmentReferences(fragment, allFragments);
+      references.push(...innerFragmentReferences, selection.name.value);
     }
-  });
+  };
+  if (node.kind === "OperationDefinition") {
+    node.selectionSet.selections.forEach((selection) => {
+      var _a;
+      if (selection.kind === "Field") {
+        (_a = selection.selectionSet) == null ? void 0 : _a.selections.forEach(handleSelectionNode);
+      }
+    });
+  } else {
+    node.selectionSet.selections.forEach(handleSelectionNode);
+  }
   return references;
 };
 var generateContentsFromGraphqlString = (graphqlString, mapDocumentNode) => {
@@ -155,7 +162,7 @@ var generateContentsFromGraphqlString = (graphqlString, mapDocumentNode) => {
   const lines = graphqlDocument.definitions.reduce((accumulator, definition) => {
     if (definition.kind === "OperationDefinition" && definition.name && definition.name.value) {
       const name = definition.name.value;
-      const fragmentsForOperation = collectAllFragmentReferences(definition);
+      const fragmentsForOperation = collectAllFragmentReferences(definition, allFragments);
       const fragments = fragmentsForOperation.map((fragmentForOperation) => {
         const fragment = allFragments[fragmentForOperation];
         if (!fragment) {

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -104,18 +104,25 @@ var collectAllFragmentDefinitions = (documentNode) => {
   };
   return accumulateAllFragments(documentNode.definitions, {});
 };
-var collectAllFragmentReferences = (operationNode) => {
+var collectAllFragmentReferences = (node, allFragments) => {
   const references = [];
-  operationNode.selectionSet.selections.forEach((selection) => {
-    var _a;
-    if (selection.kind === "Field") {
-      (_a = selection.selectionSet) == null ? void 0 : _a.selections.forEach((selection2) => {
-        if (selection2.kind === "FragmentSpread") {
-          references.push(selection2.name.value);
-        }
-      });
+  const handleSelectionNode = (selection) => {
+    if (selection.kind === "FragmentSpread") {
+      const fragment = allFragments[selection.name.value];
+      const innerFragmentReferences = collectAllFragmentReferences(fragment, allFragments);
+      references.push(...innerFragmentReferences, selection.name.value);
     }
-  });
+  };
+  if (node.kind === "OperationDefinition") {
+    node.selectionSet.selections.forEach((selection) => {
+      var _a;
+      if (selection.kind === "Field") {
+        (_a = selection.selectionSet) == null ? void 0 : _a.selections.forEach(handleSelectionNode);
+      }
+    });
+  } else {
+    node.selectionSet.selections.forEach(handleSelectionNode);
+  }
   return references;
 };
 var generateContentsFromGraphqlString = (graphqlString, mapDocumentNode) => {
@@ -125,7 +132,7 @@ var generateContentsFromGraphqlString = (graphqlString, mapDocumentNode) => {
   const lines = graphqlDocument.definitions.reduce((accumulator, definition) => {
     if (definition.kind === "OperationDefinition" && definition.name && definition.name.value) {
       const name = definition.name.value;
-      const fragmentsForOperation = collectAllFragmentReferences(definition);
+      const fragmentsForOperation = collectAllFragmentReferences(definition, allFragments);
       const fragments = fragmentsForOperation.map((fragmentForOperation) => {
         const fragment = allFragments[fragmentForOperation];
         if (!fragment) {

--- a/tests/cases/multiple-operation-imports-deep-fragments/imported-fragment.graphql
+++ b/tests/cases/multiple-operation-imports-deep-fragments/imported-fragment.graphql
@@ -1,0 +1,3 @@
+fragment SomeImportedFragment on User {
+  three
+}

--- a/tests/cases/multiple-operation-imports-deep-fragments/index.ts
+++ b/tests/cases/multiple-operation-imports-deep-fragments/index.ts
@@ -1,0 +1,3 @@
+import defaultExport from './target.graphql';
+export * from './target.graphql';
+export default defaultExport;

--- a/tests/cases/multiple-operation-imports-deep-fragments/multiple-operation-imports-deep-fragments.test.ts
+++ b/tests/cases/multiple-operation-imports-deep-fragments/multiple-operation-imports-deep-fragments.test.ts
@@ -1,0 +1,59 @@
+import path from 'path';
+
+import {
+  findDefinitionNodeByName,
+  generateJSONDocumentNodeFromOperationDefinition,
+  getJSONDocumentNodeFromString,
+  importFileAsString,
+} from '../utilities';
+import * as AllExports from './output';
+
+describe('multiple operation imports deep fragments', () => {
+  it('generates the expected output', () => {
+    const targetFile = path.join(__dirname, './target.graphql');
+    const externalFragmentFile = path.join(
+      __dirname,
+      './imported-fragment.graphql'
+    );
+
+    return Promise.all([
+      importFileAsString(targetFile, 2),
+      importFileAsString(externalFragmentFile),
+    ]).then(([targetFileData, fragmentFileData]) => {
+      const expectedDataString = fragmentFileData + targetFileData;
+      const expected = getJSONDocumentNodeFromString(expectedDataString);
+      const targetDocument = getJSONDocumentNodeFromString(targetFileData);
+      const externalFragmentDocument = getJSONDocumentNodeFromString(
+        fragmentFileData
+      );
+      const queryDefinition = findDefinitionNodeByName(targetDocument, 'Query');
+      const anotherQueryDefinition = findDefinitionNodeByName(
+        targetDocument,
+        'AnotherQuery'
+      );
+      const firstInternalFragment = findDefinitionNodeByName(
+        targetDocument,
+        'SomeFragmentAfterTheQuery'
+      );
+      const secondInternalFragment = findDefinitionNodeByName(
+        targetDocument,
+        'SomeFragmentBeforeTheQuery'
+      );
+      const externalFragment = findDefinitionNodeByName(
+        externalFragmentDocument,
+        'SomeImportedFragment'
+      );
+      expect(AllExports).toEqual({
+        default: expected,
+        Query: generateJSONDocumentNodeFromOperationDefinition(
+          queryDefinition,
+          [externalFragment, secondInternalFragment, firstInternalFragment]
+        ),
+        AnotherQuery: generateJSONDocumentNodeFromOperationDefinition(
+          anotherQueryDefinition,
+          [externalFragment]
+        ),
+      });
+    });
+  });
+});

--- a/tests/cases/multiple-operation-imports-deep-fragments/target.graphql
+++ b/tests/cases/multiple-operation-imports-deep-fragments/target.graphql
@@ -1,0 +1,23 @@
+#import ./imported-fragment.graphql
+
+fragment SomeFragmentBeforeTheQuery on User {
+  ...SomeImportedFragment
+  two
+}
+
+query Query {
+  getUsers {
+    ...SomeFragmentAfterTheQuery
+  }
+}
+
+fragment SomeFragmentAfterTheQuery on User {
+  ...SomeFragmentBeforeTheQuery
+  one
+}
+
+query AnotherQuery {
+  getUsers {
+    ...SomeImportedFragment
+  }
+}

--- a/tests/cases/multiple-operation-imports/multiple-operation-imports.test.ts
+++ b/tests/cases/multiple-operation-imports/multiple-operation-imports.test.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import {
+  findDefinitionNodeByName,
   generateJSONDocumentNodeFromOperationDefinition,
   getJSONDocumentNodeFromString,
   importFileAsString,
@@ -13,25 +14,44 @@ describe('multiple operation imports', () => {
     return importFileAsString(targetFile).then((data) => {
       const expected = getJSONDocumentNodeFromString(data);
 
+      const queryADefinition = findDefinitionNodeByName(expected, 'QueryA');
+      const queryBDefinition = findDefinitionNodeByName(expected, 'QueryB');
+      const mutationADefinition = findDefinitionNodeByName(
+        expected,
+        'MutationA'
+      );
+      const mutationBDefinition = findDefinitionNodeByName(
+        expected,
+        'MutationB'
+      );
+      const subscriptionADefinition = findDefinitionNodeByName(
+        expected,
+        'SubscriptionA'
+      );
+      const subscriptionBDefinition = findDefinitionNodeByName(
+        expected,
+        'SubscriptionB'
+      );
+
       expect(AllExports).toEqual({
         default: expected,
         QueryA: generateJSONDocumentNodeFromOperationDefinition(
-          expected.definitions[0]
+          queryADefinition
         ),
         QueryB: generateJSONDocumentNodeFromOperationDefinition(
-          expected.definitions[1]
+          queryBDefinition
         ),
         MutationA: generateJSONDocumentNodeFromOperationDefinition(
-          expected.definitions[2]
+          mutationADefinition
         ),
         MutationB: generateJSONDocumentNodeFromOperationDefinition(
-          expected.definitions[3]
+          mutationBDefinition
         ),
         SubscriptionA: generateJSONDocumentNodeFromOperationDefinition(
-          expected.definitions[4]
+          subscriptionADefinition
         ),
         SubscriptionB: generateJSONDocumentNodeFromOperationDefinition(
-          expected.definitions[5]
+          subscriptionBDefinition
         ),
       });
     });


### PR DESCRIPTION
This changes makes it such that fragments that reference other fragments are able to work for
operations. Previously, only the initial layer of fragments would be added to operation definitions.