### PR TITLE
feat: support graphql imports that wrap paths in quotation marks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,8 @@ var parseGraphQLFile = (filePath) => new Promise((resolve) => {
   let hasExhaustedImports = false;
   const parseImportAndCapture = (importCommentPrefix, line) => {
     const relativePath = line.replace(importCommentPrefix, "");
-    const absolutePath = path.default.join(path.default.dirname(filePath), relativePath);
+    const relativePathWithoutQuotations = relativePath.replace(/"|'/g, "");
+    const absolutePath = path.default.join(path.default.dirname(filePath), relativePathWithoutQuotations);
     imports.push({
       absolutePath,
       relativePath

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -32,7 +32,8 @@ var parseGraphQLFile = (filePath) => new Promise((resolve) => {
   let hasExhaustedImports = false;
   const parseImportAndCapture = (importCommentPrefix, line) => {
     const relativePath = line.replace(importCommentPrefix, "");
-    const absolutePath = path2.join(path2.dirname(filePath), relativePath);
+    const relativePathWithoutQuotations = relativePath.replace(/"|'/g, "");
+    const absolutePath = path2.join(path2.dirname(filePath), relativePathWithoutQuotations);
     imports.push({
       absolutePath,
       relativePath

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,11 @@ const parseGraphQLFile = (filePath: string): Promise<ParsedGraphQLFile> =>
       line: string
     ): void => {
       const relativePath = line.replace(importCommentPrefix, '');
-      const absolutePath = path.join(path.dirname(filePath), relativePath);
+      const relativePathWithoutQuotations = relativePath.replace(/"|'/g, '');
+      const absolutePath = path.join(
+        path.dirname(filePath),
+        relativePathWithoutQuotations
+      );
       imports.push({
         absolutePath,
         relativePath,

--- a/tests/cases/simple-graphql-import-case-with-quotations/index.ts
+++ b/tests/cases/simple-graphql-import-case-with-quotations/index.ts
@@ -1,0 +1,3 @@
+import schema from './target.graphql';
+
+export default schema;

--- a/tests/cases/simple-graphql-import-case-with-quotations/simple-graphql-import-case-with-quotations.test.ts
+++ b/tests/cases/simple-graphql-import-case-with-quotations/simple-graphql-import-case-with-quotations.test.ts
@@ -1,0 +1,24 @@
+import path from 'path';
+
+import {
+  getJSONDocumentNodeFromString,
+  importFileAsString,
+} from '../utilities';
+import output from './output';
+
+describe('simple graphql import case with quotations', () => {
+  it('generates the expected output', () => {
+    const targetFile = path.join(__dirname, './target.graphql');
+    const userFile = path.join(__dirname, './user.graphql');
+
+    return Promise.all([
+      importFileAsString(targetFile, 2),
+      importFileAsString(userFile),
+    ]).then(([targetData, userData]) => {
+      const expectedDataString = userData + targetData;
+      const expected = getJSONDocumentNodeFromString(expectedDataString);
+
+      expect(output).toEqual(expected);
+    });
+  });
+});

--- a/tests/cases/simple-graphql-import-case-with-quotations/target.graphql
+++ b/tests/cases/simple-graphql-import-case-with-quotations/target.graphql
@@ -1,0 +1,14 @@
+#import "./user.graphql"
+
+type Post {
+  id: ID!
+  author: User!
+}
+
+type Query {
+  posts: [Post!]!
+}
+
+schema {
+  query: Query
+}

--- a/tests/cases/simple-graphql-import-case-with-quotations/user.graphql
+++ b/tests/cases/simple-graphql-import-case-with-quotations/user.graphql
@@ -1,0 +1,5 @@
+type User {
+  id: ID!
+  name: String!
+  email: String!
+}

--- a/tests/cases/simple-graphql-import-case-with-single-quotations/index.ts
+++ b/tests/cases/simple-graphql-import-case-with-single-quotations/index.ts
@@ -1,0 +1,3 @@
+import schema from './target.graphql';
+
+export default schema;

--- a/tests/cases/simple-graphql-import-case-with-single-quotations/simple-graphql-import-case-with-single-quotations.test.ts
+++ b/tests/cases/simple-graphql-import-case-with-single-quotations/simple-graphql-import-case-with-single-quotations.test.ts
@@ -1,0 +1,24 @@
+import path from 'path';
+
+import {
+  getJSONDocumentNodeFromString,
+  importFileAsString,
+} from '../utilities';
+import output from './output';
+
+describe('simple graphql import case with single quotations', () => {
+  it('generates the expected output', () => {
+    const targetFile = path.join(__dirname, './target.graphql');
+    const userFile = path.join(__dirname, './user.graphql');
+
+    return Promise.all([
+      importFileAsString(targetFile, 2),
+      importFileAsString(userFile),
+    ]).then(([targetData, userData]) => {
+      const expectedDataString = userData + targetData;
+      const expected = getJSONDocumentNodeFromString(expectedDataString);
+
+      expect(output).toEqual(expected);
+    });
+  });
+});

--- a/tests/cases/simple-graphql-import-case-with-single-quotations/target.graphql
+++ b/tests/cases/simple-graphql-import-case-with-single-quotations/target.graphql
@@ -1,0 +1,14 @@
+#import './user.graphql'
+
+type Post {
+  id: ID!
+  author: User!
+}
+
+type Query {
+  posts: [Post!]!
+}
+
+schema {
+  query: Query
+}

--- a/tests/cases/simple-graphql-import-case-with-single-quotations/user.graphql
+++ b/tests/cases/simple-graphql-import-case-with-single-quotations/user.graphql
@@ -1,0 +1,5 @@
+type User {
+  id: ID!
+  name: String!
+  email: String!
+}


### PR DESCRIPTION
This change allows for import paths to have single or double quotation marks.

re #11