### PR TITLE
Run CI on Both Push and Pull Request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,4 +78,4 @@ jobs:
         run: yarn test
     timeout-minutes: 2
 name: Continuous Integration
-on: [pull_request]
+on: [push, pull_request]


### PR DESCRIPTION
This fixes post-merge CI while also causing double runs on PRs. That can be fixed afterwards.